### PR TITLE
refactor: centralize repeated error strings in a single file

### DIFF
--- a/constants/errors.go
+++ b/constants/errors.go
@@ -1,0 +1,48 @@
+package constants
+
+const (
+	ErrorConfiguringAPIURL           = "error while configuring API server URL"
+	ErrorGeneratingOperatorChallenge = "error while generating operator challenge"
+	ErrorOperatorSignIn              = "error while performing operator signin"
+	ErrorCreatingOperator            = "error while creating operator"
+	ErrorStoringSession              = "error while storing file path configuration"
+	ErrorTenantDescriptionSize       = "tenant description is over 200 characters"
+	ErrorRetrievingOperator          = "error while retrieving operator id"
+	ErrorForgingOperatorDeleteToken  = "error while forging operator delete token"
+	ErrorDeletingTenant              = "error while deleting tenant"
+
+	ErrorImageURL            = "image url is not adequate"
+	ErrorLoadingConfig       = "error while loading file path configuration"
+	ErrorGeneratingToken     = "error while generating access and refresh tokens"
+	ErrorParsingJsonSettings = "error while parsing json settings"
+	ErrorOpeningJson         = "error while opening json file"
+	ErrorWritingCvsRecord    = "error writing record to csv"
+	ErrorFlush               = "error occurred during the Flush"
+
+	ErrorCreatingTenant                  = "error while creating tenant"
+	ErrorEditingTenant                   = "error while editing tenant"
+	ErrorRetrievingTenant                = "error while retrieving tenant"
+	ErrorRetrievingTenantList            = "error while retrieving tenant list"
+	ErrorRetrievingTenantDescription     = "error while retrieving tenant description"
+	ErrorTenantNameOrID                  = "error, tenant name or id incorrect"
+	ErrorRetrievingAvailableTenantSwarms = "error while retrieving available tenant swarms list"
+
+	ErrorGeneratingOperatorChallengeRequest = "failed request to generate operator challenge"
+	ErrorGettingOperatorRequest             = "failed request to get operator"
+	ErrorSignRequest                        = "failed request to sign in"
+	ErrorEmptyToken                         = "access token cannot be empty"
+	ErrorRefreshToken                       = "refresh token cannot be empty"
+	ErrorCreatingOperatorRequest            = "failed to create operator request"
+	ErrorForgingRequest                     = "failed to forge token request"
+	ErrorTokenExpiration                    = "wrong token expiration returned"
+	ErrorTokenNotFound                      = "error token not found"
+	ErrorListingTenantsRequest              = "failed request to list tenants request"
+	ErrorDeletingTenantRequest              = "failed request to delete tenant"
+	ErrorEditingTenantRequest               = "failed request to edit tenant "
+	ErrorListingTenantSwarmsRequest         = "failed request to list tenant available swarms"
+
+	ErrorIamConfigNotFound   = "iam api server url is not defined in configuration"
+	ErrorHiveConfigNotFound  = "hive api server url is not defined in configuration"
+	ErrorTokenConfigNotFound = "refresh token is not defined in configuration file"
+	ErrorNameConfigNotFound  = "name is not defined in configuration file"
+)

--- a/src/action/login.go
+++ b/src/action/login.go
@@ -20,7 +20,7 @@ func SignInOperatorInteractive(ctx *cli.Context) error {
 	apiServerUrl := input.TextPrompt("Enter the api server url: (default https://api.cubbit.eu)")
 
 	if urls, err = configuration.ConfigureAPIServerURL(apiServerUrl); err != nil {
-		return fmt.Errorf("error while configuri api server url %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorConfiguringAPIURL, err)
 	}
 
 	email := input.TextPrompt("Enter email:")
@@ -41,11 +41,11 @@ func SignInOperatorInteractive(ctx *cli.Context) error {
 	}
 
 	if challenge, err = api.GenerateOperatorChallenge(*urls, email); err != nil {
-		return fmt.Errorf("error while generating operator challenge: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingOperatorChallenge, err)
 	}
 
 	if refreshToken, err = api.PerformOperatorSignin(*urls, email, password, challenge, code); err != nil {
-		return fmt.Errorf("error while performing operator signin: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorOperatorSignIn, err)
 	}
 
 	conf = configuration.NewConfig(profile, *urls, refreshToken)
@@ -74,7 +74,7 @@ func SignInOperator(ctx *cli.Context) error {
 
 	profile := ctx.String("profile")
 	if profile == "" {
-		profile = "default"
+		profile = constants.DefaultProfile
 	}
 
 	email = ctx.String("email")
@@ -83,21 +83,21 @@ func SignInOperator(ctx *cli.Context) error {
 	apiServerUrl = ctx.String("api-server-url")
 
 	if urls, err = configuration.ConfigureAPIServerURL(apiServerUrl); err != nil {
-		return fmt.Errorf("error while configuri api server url %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorConfiguringAPIURL, err)
 	}
 
 	if challenge, err = api.GenerateOperatorChallenge(*urls, email); err != nil {
-		return fmt.Errorf("error while generating operator challenge: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingOperatorChallenge, err)
 	}
 
 	if refreshToken, err = api.PerformOperatorSignin(*urls, email, password, challenge, code); err != nil {
-		return fmt.Errorf("error while performing operator singin: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorOperatorSignIn, err)
 	}
 
 	var confs = configuration.NewConfig(profile, *urls, refreshToken)
 
 	if err = confs.StoreSession(configPath); err != nil {
-		return fmt.Errorf("error while storing file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorStoringSession, err)
 	}
 
 	fmt.Printf("User %s signed in successfully\n", email)

--- a/src/action/logout.go
+++ b/src/action/logout.go
@@ -19,13 +19,13 @@ func SignOutOperatorInteractive(cCtx *cli.Context) error {
 
 	profile := input.TextPrompt("Enter the configuration profile (default: default)")
 	if profile == "" {
-		profile = "default"
+		profile = constants.DefaultProfile
 	}
 
 	var conf = configuration.NewConfig(profile, configuration.Url{}, "")
 
 	if err = conf.StoreSession(configPath); err != nil {
-		return fmt.Errorf("error while storing file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorStoringSession, err)
 	}
 
 	fmt.Printf("Configuration %s signed out successfully\n", profile)
@@ -42,7 +42,7 @@ func SignOutOperator(ctx *cli.Context) error {
 
 	profile := ctx.String("profile")
 	if profile == "" {
-		profile = "default"
+		profile = constants.DefaultProfile
 	}
 
 	configPath := ctx.String("config")
@@ -53,7 +53,7 @@ func SignOutOperator(ctx *cli.Context) error {
 	var conf = configuration.NewConfig(profile, configuration.Url{}, "")
 
 	if err = conf.StoreSession(configPath); err != nil {
-		return fmt.Errorf("error while storing file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorStoringSession, err)
 	}
 
 	fmt.Printf("Configuration %s signed out successfully\n", profile)

--- a/src/action/operator.go
+++ b/src/action/operator.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 
+	"github.com/cubbit/cubbit/client/cli/constants"
 	"github.com/cubbit/cubbit/client/cli/src/api"
 	"github.com/cubbit/cubbit/client/cli/src/configuration"
 	"github.com/cubbit/cubbit/client/cli/src/input"
@@ -16,7 +17,7 @@ func CreateOperatorInteractive(ctx *cli.Context) error {
 	apiServerUrl := input.TextPrompt("Enter the api server url: (default https://api.cubbit.eu)")
 
 	if urls, err = configuration.ConfigureAPIServerURL(apiServerUrl); err != nil {
-		return fmt.Errorf("error while configuri api server url %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorConfiguringAPIURL, err)
 	}
 
 	firstName := input.TextPrompt("Enter first name:")
@@ -26,7 +27,7 @@ func CreateOperatorInteractive(ctx *cli.Context) error {
 	secret := input.PasswordPrompt("Enter secret:")
 
 	if err = api.CreateOperator(*urls, firstName, lastName, email, password, secret); err != nil {
-		return fmt.Errorf("error while creating operator: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorCreatingOperator, err)
 	}
 
 	fmt.Printf("Operator %s created successfully\n", email)
@@ -50,11 +51,11 @@ func CreateOperator(ctx *cli.Context) error {
 	secret := ctx.String("secret")
 
 	if urls, err = configuration.ConfigureAPIServerURL(apiServerUrl); err != nil {
-		return fmt.Errorf("error while configuri api server url %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorConfiguringAPIURL, err)
 	}
 
 	if err = api.CreateOperator(*urls, firstName, lastName, email, password, secret); err != nil {
-		return fmt.Errorf("error while creating operator: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorCreatingOperator, err)
 	}
 
 	fmt.Printf("Operator %s created successfully\n", email)

--- a/src/action/tenant.go
+++ b/src/action/tenant.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/cubbit/cubbit/client/cli/constants"
 	"github.com/cubbit/cubbit/client/cli/src/api"
 	"github.com/cubbit/cubbit/client/cli/src/configuration"
 	"github.com/urfave/cli/v2"
@@ -22,13 +23,13 @@ func CreateTenant(ctx *cli.Context) error {
 	name := ctx.String("name")
 	description := ctx.Args().First()
 	if len(description) > 200 {
-		return fmt.Errorf("tenant description is over 200 characters: %w", err)
+		return fmt.Errorf("t%s: %w", constants.ErrorTenantDescriptionSize, err)
 	}
 
 	imageUrl := ctx.String("image-url")
 	if imageUrl != "" {
 		if _, err := url.ParseRequestURI(imageUrl); err != nil {
-			return fmt.Errorf("image url is not adequate: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorImageURL, err)
 		}
 	}
 
@@ -38,20 +39,20 @@ func CreateTenant(ctx *cli.Context) error {
 	}
 
 	if conf, configPath, err = configuration.ReadConfig(ctx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	var settings map[string]interface{}
 
 	if err = json.Unmarshal([]byte(settingsString), &settings); err != nil {
-		return fmt.Errorf("error while parsing json settings: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorParsingJsonSettings, err)
 	}
 
 	if response, err = api.CreateTenant(conf.Urls, *accessToken, name, &description, &imageUrl, settings); err != nil {
-		return fmt.Errorf("error while creating the tenant: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorCreatingTenant, err)
 	}
 
 	fmt.Printf("Successfully created tenant: %s\n", response.ID)
@@ -69,17 +70,17 @@ func ListTenant(cCtx *cli.Context) error {
 	fmt.Println("these are your tenants")
 
 	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	if operator, err = api.GetOperatorSelf(conf.Urls, *accessToken); err != nil {
-		return fmt.Errorf("error while retrieving operator id: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingOperator, err)
 	}
 	if tenants, err = api.ListTenants(conf.Urls, *accessToken, operator.ID); err != nil {
-		return fmt.Errorf("error while retrieving tenant list: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantList, err)
 	}
 
 	verbose := cCtx.Bool("verbose")
@@ -117,11 +118,11 @@ func RemoveTenant(cCtx *cli.Context) error {
 	}
 
 	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	if id == "" {
@@ -129,10 +130,10 @@ func RemoveTenant(cCtx *cli.Context) error {
 		var tenants *api.TenantList
 
 		if operator, err = api.GetOperatorSelf(conf.Urls, *accessToken); err != nil {
-			return fmt.Errorf("error while retrieving operator id: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorRetrievingOperator, err)
 		}
 		if tenants, err = api.ListTenants(conf.Urls, *accessToken, operator.ID); err != nil {
-			return fmt.Errorf("error while retrieving tenant list: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantList, err)
 		}
 		for _, tenant := range tenants.Tenants {
 			if name == tenant.Name {
@@ -146,15 +147,15 @@ func RemoveTenant(cCtx *cli.Context) error {
 	}
 
 	if challenge, err = api.GenerateOperatorChallenge(conf.Urls, email); err != nil {
-		return fmt.Errorf("error while generating operator challenge: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingOperatorChallenge, err)
 	}
 
 	if deleteTenantToken, err = api.ForgeOperatorDeleteTenantToken(conf.Urls, email, password, conf.RefreshToken, challenge, code, id); err != nil {
-		return fmt.Errorf("error while forging operator delete token: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorForgingOperatorDeleteToken, err)
 	}
 
 	if err = api.RemoveTenant(conf.Urls, *accessToken, id, deleteTenantToken); err != nil {
-		return fmt.Errorf("error while deleting tenant: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorDeletingTenant, err)
 	}
 
 	fmt.Printf("tenant %s removed successfully\n", id)
@@ -170,25 +171,25 @@ func DescribeTenant(cCtx *cli.Context) error {
 	var operator *api.Operator
 
 	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	id := cCtx.String("id")
 	name := cCtx.String("name")
 	format := cCtx.String("format")
 	if operator, err = api.GetOperatorSelf(conf.Urls, *accessToken); err != nil {
-		return fmt.Errorf("error while retrieving operator id: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingOperator, err)
 	}
 	if tenants, err = api.ListTenants(conf.Urls, *accessToken, operator.ID); err != nil {
-		return fmt.Errorf("error while retrieving tenant list: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantList, err)
 	}
 
 	switch {
 	case id == "" && name == "":
-		return fmt.Errorf("error while retrieving tenant description: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantDescription, err)
 	case name == "":
 		for _, tenant := range tenants.Tenants {
 			if id == tenant.ID {
@@ -202,7 +203,7 @@ func DescribeTenant(cCtx *cli.Context) error {
 			}
 		}
 	default:
-		return fmt.Errorf("error, tenant name or id incorrect: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorTenantNameOrID, err)
 	}
 
 	return nil
@@ -238,7 +239,7 @@ func FormatTenant(format string, tenant *api.Tenant) error {
 		formatJson, err := json.Marshal(api.Tenant{ID: tenant.ID, Name: tenant.Name, Description: tenant.Description, OwnerID: tenant.OwnerID, CreatedAt: tenant.CreatedAt, DeletedAt: tenant.DeletedAt, ImageUrl: tenant.ImageUrl, Settings: tenant.Settings})
 
 		if err != nil {
-			return fmt.Errorf("error while opening json file: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorOpeningJson, err)
 		}
 
 		fmt.Println(string(formatJson))
@@ -265,14 +266,14 @@ func FormatTenant(format string, tenant *api.Tenant) error {
 
 		for _, record := range records {
 			if err := w.Write(record); err != nil {
-				return fmt.Errorf("error writing record to csv: %w", err)
+				return fmt.Errorf("%s: %w", constants.ErrorWritingCvsRecord, err)
 			}
 		}
 
 		w.Flush()
 
 		if err := w.Error(); err != nil {
-			return fmt.Errorf("error occurred during the Flush: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorFlush, err)
 		}
 	}
 
@@ -280,77 +281,77 @@ func FormatTenant(format string, tenant *api.Tenant) error {
 	return nil
 }
 
-func EditTenantDescription(cCtx *cli.Context) error {
+func EditTenantDescription(ctx *cli.Context) error {
 	var err error
 	var accessToken *string
 	var configPath string
 	var conf *configuration.Config
 
-	name := cCtx.String("name")
-	id := cCtx.String("id")
+	name := ctx.String("name")
+	id := ctx.String("id")
 
 	if id == "" && name == "" {
 		return fmt.Errorf("invalid tenant id or name: %w", err)
 	}
 
-	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+	if conf, configPath, err = configuration.ReadConfig(ctx); err != nil {
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
 		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
 	}
 
-	if cCtx.Args().Len() != 1 {
+	if ctx.Args().Len() != 1 {
 		return fmt.Errorf("invalid image url: %w", err)
 	}
 
-	description := cCtx.Args().First()
+	description := ctx.Args().First()
 	if len(description) > 200 {
 		fmt.Println(description)
-		return fmt.Errorf("tenant description is over 200 characters: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorTenantDescriptionSize, err)
 	}
 
 	if err = api.EditTenantDescription(conf.Urls, *accessToken, id, description); err != nil {
-		return fmt.Errorf("error while retrieving tenant list: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantDescription, err)
 	}
 
 	fmt.Printf("tenant %s description updated successfully\n", id)
 	return nil
 }
 
-func EditTenantImage(cCtx *cli.Context) error {
+func EditTenantImage(ctx *cli.Context) error {
 	var err error
 	var accessToken *string
 	var configPath string
 	var conf *configuration.Config
 
-	name := cCtx.String("name")
-	id := cCtx.String("id")
+	name := ctx.String("name")
+	id := ctx.String("id")
 
 	if id == "" && name == "" {
-		return fmt.Errorf("invalid tenant id or name: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorTenantNameOrID, err)
 	}
 
-	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+	if conf, configPath, err = configuration.ReadConfig(ctx); err != nil {
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
-	if cCtx.Args().Len() != 1 {
-		return fmt.Errorf("invalid umage url: %w", err)
+	if ctx.Args().Len() != 1 {
+		return fmt.Errorf("%s: %w", constants.ErrorImageURL, err)
 	}
 
-	image := cCtx.Args().First()
+	image := ctx.Args().First()
 	if image != "" {
 		if _, err := url.ParseRequestURI(image); err != nil {
-			return fmt.Errorf("image url is not adequate: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorImageURL, err)
 		}
 	}
 
 	if err = api.EditTenantImage(conf.Urls, *accessToken, id, image); err != nil {
-		return fmt.Errorf("error while retrieving tenant list: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorEditingTenant, err)
 	}
 
 	fmt.Printf("tenant %s image updated successfully\n", id)
@@ -368,34 +369,34 @@ func ListAvailableSwarmsTenant(cCtx *cli.Context) error {
 	name := cCtx.String("name")
 
 	if id == "" && name == "" {
-		return fmt.Errorf("invalid tenant id or name: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorTenantNameOrID, err)
 	}
 
 	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	if id == "" {
 		if id, err = getTenantByName(conf, accessToken, name); err != nil {
-			return fmt.Errorf("error while retrieving id: %w", err)
+			return fmt.Errorf("%s: %w", constants.ErrorRetrievingTenant, err)
 		}
 	}
 
 	fmt.Printf("those are the swarms connect to the tenant %s\n", id)
 
 	if conf, configPath, err = configuration.ReadConfig(cCtx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	if swarms, err = api.ListAvailableTenantSwarms(conf.Urls, *accessToken, id); err != nil {
-		return fmt.Errorf("error while retrieving available swarms list: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorRetrievingAvailableTenantSwarms, err)
 	}
 
 	for _, swarm := range swarms.Swarms {
@@ -417,7 +418,7 @@ func getTenantByName(conf *configuration.Config, accessToken *string, name strin
 	var id string
 
 	if tenants, err = api.ListTenants(conf.Urls, *accessToken, operator.ID); err != nil {
-		return "", fmt.Errorf("error while retrieving tenant list: %w", err)
+		return "", fmt.Errorf("%s: %w", constants.ErrorRetrievingTenantList, err)
 	}
 	for _, tenant := range tenants.Tenants {
 		if name == tenant.Name {

--- a/src/action/token.go
+++ b/src/action/token.go
@@ -2,6 +2,8 @@ package action
 
 import (
 	"fmt"
+
+	"github.com/cubbit/cubbit/client/cli/constants"
 	"github.com/cubbit/cubbit/client/cli/src/api"
 	"github.com/cubbit/cubbit/client/cli/src/configuration"
 	"github.com/urfave/cli/v2"
@@ -14,14 +16,14 @@ func GenerateAccessToken(ctx *cli.Context) error {
 	var conf *configuration.Config
 
 	if conf, configPath, err = configuration.ReadConfig(ctx); err != nil {
-		return fmt.Errorf("error while loading file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 	if accessToken, err = rehydrateTokenConfig(configPath, conf); err != nil {
-		return fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	if err = conf.StoreSession(configPath); err != nil {
-		return fmt.Errorf("error while storing file path configuration: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorStoringSession, err)
 	}
 
 	fmt.Printf("Access token: %s\n", *accessToken)
@@ -34,13 +36,13 @@ func rehydrateTokenConfig(configPath string, conf *configuration.Config) (*strin
 	var err error
 
 	if accessToken, refreshToken, err = api.RefreshOperatorAccessToken(conf.Urls, conf.RefreshToken); err != nil {
-		return nil, fmt.Errorf("error while generating access and refresh tokens: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorGeneratingToken, err)
 	}
 
 	conf.RefreshToken = refreshToken
 
 	if err = conf.StoreSession(configPath); err != nil {
-		return nil, fmt.Errorf("error while storing file path configuration: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorStoringSession, err)
 	}
 
 	return &accessToken, nil

--- a/src/api/authentication_client.go
+++ b/src/api/authentication_client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,7 +30,7 @@ func GenerateOperatorChallenge(urls configuration.Url, email string) (*Challenge
 		request_utils.WithExpectedStatusCode(http.StatusOK),
 		extractChallengeResponseModel(&response),
 	); err != nil {
-		return nil, fmt.Errorf("failed unable to create get operator request: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorGeneratingOperatorChallengeRequest, err)
 	}
 
 	return &response, nil
@@ -68,19 +67,19 @@ func PerformOperatorSignin(urls configuration.Url, email, password string, chall
 		extractTokenExpirationModel(&tokenExpirationResponse),
 		extractRefreshCookie(&refreshTokenCookie),
 	); err != nil {
-		return "", fmt.Errorf("failed unable to sign in request: %w", err)
+		return "", fmt.Errorf("%s: %w", constants.ErrorSignRequest, err)
 	}
 
 	if tokenExpirationResponse.Exp == 0 {
-		return "", fmt.Errorf("wrong token expiration returned")
+		return "", fmt.Errorf(constants.ErrorTokenExpiration)
 	}
 
 	if tokenExpirationResponse.Token == "" {
-		return "", errors.New("access token cannot be empty")
+		return "", fmt.Errorf(constants.ErrorEmptyToken)
 	}
 
 	if refreshTokenCookie == "" {
-		return "", errors.New("refresh token cannot be empty")
+		return "", fmt.Errorf(constants.ErrorRefreshToken)
 	}
 
 	return refreshTokenCookie, nil
@@ -112,7 +111,7 @@ func CreateOperator(urls configuration.Url, firstName, lastName, email, password
 	}
 
 	if err = request_utils.DoRequest(url, request_utils.WithRequestMethod(http.MethodPost), request_utils.WithRequestBody(requestBody), request_utils.WithExpectedStatusCode(http.StatusNoContent)); err != nil {
-		return fmt.Errorf("failed unable to create operator request: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorCreatingOperatorRequest, err)
 	}
 
 	return nil
@@ -141,15 +140,15 @@ func getOperatorAccessToken(refreshToken string, url string) (string, string, er
 		extractTokenExpirationModel(&tokenExpirationResponse),
 		extractRefreshCookie(&refreshToken),
 	); err != nil {
-		return "", "", fmt.Errorf("failed unable to forge token request: %w", err)
+		return "", "", fmt.Errorf("%s: %w", constants.ErrorForgingRequest, err)
 	}
 
 	if tokenExpirationResponse.Exp == 0 {
-		return "", "", fmt.Errorf("wrong token expiration returned xxx")
+		return "", "", fmt.Errorf(constants.ErrorTokenExpiration)
 	}
 
 	if tokenExpirationResponse.Token == "" {
-		return "", "", errors.New("access token cannot be empty")
+		return "", "", fmt.Errorf(constants.ErrorEmptyToken)
 	}
 
 	return tokenExpirationResponse.Token, refreshToken, nil
@@ -187,15 +186,15 @@ func ForgeOperatorDeleteTenantToken(urls configuration.Url, email, password, ref
 		request_utils.WithRequestBody(body),
 		extractTokenExpirationModel(&tokenExpirationResponse),
 	); err != nil {
-		return "", fmt.Errorf("failed unable to forge token request: %w", err)
+		return "", fmt.Errorf("%s: %w", constants.ErrorForgingRequest, err)
 	}
 
 	if tokenExpirationResponse.Exp == 0 {
-		return "", fmt.Errorf("wrong token expiration returned")
+		return "", fmt.Errorf(constants.ErrorTokenExpiration)
 	}
 
 	if tokenExpirationResponse.Token == "" {
-		return "", errors.New("access token cannot be empty")
+		return "", fmt.Errorf(constants.ErrorEmptyToken)
 	}
 
 	return tokenExpirationResponse.Token, nil

--- a/src/api/operator.go
+++ b/src/api/operator.go
@@ -21,7 +21,7 @@ func GetOperator(urls configuration.Url, accessToken, meOrID string) (*Operator,
 		request_utils.WithAccessToken(accessToken),
 		extractOperatorResponseModel(&operator),
 	); err != nil {
-		return nil, fmt.Errorf("failed: unable to get an operator: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorGettingOperatorRequest, err)
 	}
 
 	return &operator, nil

--- a/src/api/response_extractors.go
+++ b/src/api/response_extractors.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -43,11 +42,11 @@ func extractRefreshCookie(response *string) request_utils.RequestModifier {
 			return c.Name == constants.RefreshTokenName
 		})
 		if !found {
-			return fmt.Errorf("refresh token not found in cookies")
+			return fmt.Errorf(constants.ErrorTokenNotFound)
 		}
 
 		if refreshTokenCookie.Value == "" {
-			return errors.New("refresh token cannot be empty")
+			return fmt.Errorf(constants.ErrorEmptyToken)
 		}
 
 		*response = refreshTokenCookie.Value

--- a/src/api/tenant.go
+++ b/src/api/tenant.go
@@ -35,7 +35,7 @@ func CreateTenant(urls configuration.Url, accessToken, name string, description 
 		extractGenericIDResponseModel(&response),
 		request_utils.WithAccessToken(accessToken),
 	); err != nil {
-		return nil, fmt.Errorf("failed unable to create get operator request: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorGettingOperatorRequest, err)
 	}
 
 	return &response, nil
@@ -52,7 +52,7 @@ func ListTenants(urls configuration.Url, accessToken, ownerID string) (*TenantLi
 		request_utils.WithExpectedStatusCode(http.StatusOK),
 		extractTenantListModel(&response),
 	); err != nil {
-		return nil, fmt.Errorf("failed unable to list tenants request: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorListingTenantsRequest, err)
 	}
 	return &response, nil
 }
@@ -67,7 +67,7 @@ func RemoveTenant(urls configuration.Url, accessToken, tenantId, deleteTenantTok
 		request_utils.WithAccessToken(accessToken),
 		request_utils.WithExpectedStatusCode(http.StatusNoContent),
 	); err != nil {
-		return fmt.Errorf("failed unable to delete tenant request: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorDeletingTenantRequest, err)
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func EditTenantDescription(urls configuration.Url, accessToken, tenantID, descri
 		request_utils.WithRequestBody(requestBody),
 		request_utils.WithExpectedStatusCode(http.StatusCreated),
 	); err != nil {
-		return fmt.Errorf("failed unable to edit tenant description: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorEditingTenantRequest, err)
 	}
 
 	return nil
@@ -111,7 +111,7 @@ func EditTenantImage(urls configuration.Url, accessToken, tenantID, imageUrl str
 		request_utils.WithRequestBody(requestBody),
 		request_utils.WithExpectedStatusCode(http.StatusCreated),
 	); err != nil {
-		return fmt.Errorf("failed unable to edit tenant image: %w", err)
+		return fmt.Errorf("%s: %w", constants.ErrorEditingTenantRequest, err)
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func ListAvailableTenantSwarms(urls configuration.Url, accessToken, tenantID str
 		request_utils.WithExpectedStatusCode(http.StatusOK),
 		extractSwarmListModel(&response),
 	); err != nil {
-		return nil, fmt.Errorf("failed unable to list available swarms request: %w", err)
+		return nil, fmt.Errorf("%s: %w", constants.ErrorListingTenantSwarmsRequest, err)
 	}
 	return &response, nil
 }

--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -52,11 +52,11 @@ func (c *Config) LoadUrl(filePath string, envName string) (*Url, error) {
 	}
 
 	if urls.IamUrl == "" {
-		return nil, fmt.Errorf("iam api server url is not defined in configuration")
+		return nil, fmt.Errorf(constants.ErrorIamConfigNotFound)
 	}
 
 	if urls.HiveUrl == "" {
-		return nil, fmt.Errorf("hive api server url is not defined in configuration")
+		return nil, fmt.Errorf(constants.ErrorHiveConfigNotFound)
 	}
 
 	return &urls, nil
@@ -77,19 +77,19 @@ func (c *Config) LoadAndCheckSession(filePath string, name string) error {
 	}
 
 	if config.Urls.IamUrl == "" {
-		return fmt.Errorf("iam api server url is not defined in configuration")
+		return fmt.Errorf(constants.ErrorIamConfigNotFound)
 	}
 
 	if config.Urls.HiveUrl == "" {
-		return fmt.Errorf("hive api server url is not defined in configuration")
+		return fmt.Errorf(constants.ErrorHiveConfigNotFound)
 	}
 
 	if config.RefreshToken == "" {
-		return fmt.Errorf("refresh token is not defined in configuration")
+		return fmt.Errorf(constants.ErrorTokenNotFound)
 	}
 
 	if config.Name == "" {
-		return fmt.Errorf("name is not defined in configuration")
+		return fmt.Errorf(constants.ErrorNameConfigNotFound)
 	}
 
 	*c = config
@@ -153,7 +153,7 @@ func ReadConfig(ctx *cli.Context) (*Config, string, error) {
 	var conf = NewConfig(profile, Url{}, "")
 
 	if err = conf.LoadAndCheckSession(configPath, profile); err != nil {
-		return nil, "", fmt.Errorf("error while loading file path configuration: %w", err)
+		return nil, "", fmt.Errorf("%s: %w", constants.ErrorLoadingConfig, err)
 	}
 
 	return &conf, configPath, nil


### PR DESCRIPTION
<!-- 👆 Provide a general summary of your changes in the Title above  -->
<!-- What types of changes does your code introduce? Use labels to describe them 👉-->
## Description
<!-- Describe your changes in detail  -->
centralize repeated error strings in a single file and replaced them in files
## Motivation and Context
<!-- Why is this change required? What problem does it solve?  -->
<!-- If it fixes an open issue, please link to the issue here.  -->

## Tell me why you are supposing that this is not going to break everything
<!-- Please describe in detail how you tested your changes.  -->
<!-- Include details of your testing environment, tests ran to see how  -->
<!-- your change affects other areas of the code, etc.  -->
still keeping the implementation logic, only error strings are replaced
## Screenshots (if appropriate):
<!-- Drop relevant images here  -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply.  -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help!  -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings
- [X] I have chosen appropriate labels
- [X] The documentation is aligned with the changes
