### PR TITLE
Fix: Make Enter prompt optional in CLI browser login flow

### DIFF
--- a/src/action/auth.go
+++ b/src/action/auth.go
@@ -81,29 +81,53 @@ func performBrowserLogin(urls configuration.URLs, conf *configuration.Config, pr
 	fmt.Printf("📋 Auth URL: %s\n\n", authURL)
 	fmt.Println("Press Enter to open browser...")
 
-	// Wait for user to press Enter
-	fmt.Scanln()
+	inputChan := make(chan bool, 1)
+	apiKeyChan := make(chan string, 1)
+	errChan := make(chan error, 1)
 
-	fmt.Printf("🌐 Opening browser for authentication...\n")
-	if err = browser.OpenURL(authURL); err != nil {
-		fmt.Printf("⚠️ Failed to open browser automatically: %v\n", err)
-		fmt.Printf("Please manually visit the URL above\n\n")
-	}
+	go func() {
+		fmt.Scanln()
+		inputChan <- true
+	}()
 
-	fmt.Println("👀 Waiting for authentication...")
+	go func() {
+		key, err := pollForAPIKey(urls, uuid.String())
+		if err != nil {
+			errChan <- err
+			return
+		}
+		apiKeyChan <- key
+	}()
 
-	fmt.Println()
-	fmt.Println("📝 Please complete the authentication in your browser")
-	fmt.Println("⏳ This window will automatically continue once you're done")
-	fmt.Println()
+	select {
+	case <-inputChan:
+		fmt.Printf("🌐 Opening browser for authentication...\n")
+		if err = browser.OpenURL(authURL); err != nil {
+			fmt.Printf("⚠️ Failed to open browser automatically: %v\n", err)
+			fmt.Printf("Please manually visit the URL above\n\n")
+		} else {
+			fmt.Println("👀 Waiting for authentication...")
+		}
 
-	// Poll for API key
-	if apiKey, err = pollForAPIKey(urls, uuid.String()); err != nil {
+		fmt.Println()
+		fmt.Println("📝 Complete the authentication in your browser")
+		fmt.Println("⏳ This window will automatically continue once you're done")
+		fmt.Println()
+
+		select {
+		case apiKey = <-apiKeyChan:
+			fmt.Println("✅ Authentication successful!")
+			fmt.Printf("📜 API Key received: %s\n", apiKey)
+		case err = <-errChan:
+			return fmt.Errorf("authentication failed: %w", err)
+		}
+
+	case apiKey = <-apiKeyChan:
+		fmt.Println("✅ Authentication successful!")
+		fmt.Printf("📜 API Key received: %s\n", apiKey)
+	case err = <-errChan:
 		return fmt.Errorf("authentication failed: %w", err)
 	}
-
-	fmt.Println("✅ Authentication successful!")
-	fmt.Printf("📜 API Key: %s\n", apiKey)
 
 	if err = conf.CreateProfile(profile, configuration.ProfileTypeComposer, resolvedEndpoint, apiKey); err != nil {
 		return fmt.Errorf("failed to create profile: %w", err)
@@ -134,14 +158,13 @@ func pollForAPIKey(urls configuration.URLs, deviceID string) (string, error) {
 		case <-ticker.C:
 			apiKey, err := api.GetDeviceAPIKey(urls, deviceID)
 			if err != nil {
-				if err != nil && strings.Contains(err.Error(), "not found") {
+				if strings.Contains(err.Error(), "not found") {
 					return "", fmt.Errorf("device not found - registration may have expired")
 				}
 				return "", fmt.Errorf("failed to check authorization status: %w", err)
 			}
 
 			if apiKey != "" {
-				fmt.Println()
 				return apiKey, nil
 			}
 			// continue polling if API key is not yet available


### PR DESCRIPTION
### Summary
<!--Describe the bug and the fix at a high level. Mention the affected CLI commands.-->
Previously, the CLI blocked the login flow by requiring users to press Enter before starting the background check for the login URL. This behavior prevented API key retrieval from progressing until Enter was pressed.

### Reproduction Steps
<!--Provide minimal CLI steps to reproduce the bug.-->
<!--Example: ```bash cubbit <command> <subcommand> --flag value ... ```-->

1. Run the CLI and attempt to log in.
2. Click the displayed login URL instead of pressing Enter.
3. Input the code provided in the browser.

### Implementation Details
<!--Key changes and rationale-->

- The background login check starts automatically as soon as the login URL is displayed.
- Pressing Enter is still supported, but is no longer required to unblock the process.

### Screenshots/Recordings (if CLI output changed)

### Tests
<!--Manual verification steps (paste exact commands and expected vs actual output)-->


### Breaking Changes?
- [x] No
- [ ] Yes (describe migration or follow-up)

### Regression
- [ ] Fixes a regression
  <!--Introduced by commit/PR:-->

### Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README/changelog)
- [x] Checked lint/format
