### PR TITLE
feat(composer): replace --version flag with dedicated version command com-1083

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	cmd_docs "github.com/cubbit/composer-cli/src/cmd/docs"
 	cmd_infrastructure "github.com/cubbit/composer-cli/src/cmd/infrastructure"
 	cmd_operator "github.com/cubbit/composer-cli/src/cmd/operator"
+	cmd_version "github.com/cubbit/composer-cli/src/cmd/version"
 	"github.com/cubbit/composer-cli/src/configuration"
 	"github.com/cubbit/composer-cli/src/service"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func NewRootCommand(
 	operatorService service.OperatorServiceInterface,
 	locationService service.LocationServiceInterface,
 	configService service.ConfigServiceInterface,
+	version string,
 ) *cobra.Command {
 	rootCommand := &cobra.Command{
 		Use:   "cubbit",
@@ -65,6 +67,9 @@ func NewRootCommand(
 
 	docsCmd := cmd_docs.NewDocsCmd()
 	rootCommand.AddCommand(docsCmd)
+
+	versionCmd := cmd_version.NewVersionCmd(version)
+	rootCommand.AddCommand(versionCmd)
 
 	return rootCommand
 }

--- a/src/cmd/root_init.go
+++ b/src/cmd/root_init.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var packageJSON []byte
 var devNull *os.File
 
 type PackageData struct {
@@ -36,7 +35,12 @@ func cleanupSilentMode() {
 	}
 }
 
-var rootCmd = func() *cobra.Command {
+func Execute(packageJSON []byte) {
+	var pkg PackageData
+	if err := json.Unmarshal(packageJSON, &pkg); err != nil {
+		os.Exit(1)
+	}
+
 	configuration, err := configuration.LoadConfig()
 	if err != nil {
 		panic("failed to load config: " + err.Error())
@@ -53,16 +57,8 @@ var rootCmd = func() *cobra.Command {
 	operatorService := service.NewOperatorService(configuration, operatorAPI, userAPI)
 	configService := service.NewConfigService(configuration)
 
-	return NewRootCommand(agentService, authService, operatorService, locationService, configService)
-}()
+	rootCmd := NewRootCommand(agentService, authService, operatorService, locationService, configService, pkg.Version)
 
-func Execute(packageJSON []byte) {
-	var pkg PackageData
-	if err := json.Unmarshal(packageJSON, &pkg); err != nil {
-		os.Exit(1)
-	}
-	rootCmd.Version = pkg.Version
-	rootCmd.SetVersionTemplate("{{.Use}} version {{.Version}}\n")
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/src/cmd/version/BUILD.bazel
+++ b/src/cmd/version/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "version",
@@ -10,4 +10,13 @@ go_library(
     deps = [
         "@com_github_spf13_cobra//:go_default_library",
     ],
+)
+
+go_test(
+    name = "version_test",
+    srcs = [
+        "version_cmd_structure_test.go",
+    ],
+    embed = [":version"],
+    tags = ["unit"],
 )

--- a/src/cmd/version/BUILD.bazel
+++ b/src/cmd/version/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "version",
+    srcs = [
+        "version_cmd.go",
+    ],
+    importpath = "github.com/cubbit/composer-cli/src/cmd/version",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/src/cmd/version/version_cmd.go
+++ b/src/cmd/version/version_cmd.go
@@ -10,10 +10,10 @@ func NewVersionCmd(version string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print the CLI version",
-		Long:  "Print the current version of the Cubbit CLI",
+		Long:  "Print the current version of the CLI",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(cmd.OutOrStdout(), "cubbit version %s\n", version)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().Use, version)
 		},
 	}
 }

--- a/src/cmd/version/version_cmd.go
+++ b/src/cmd/version/version_cmd.go
@@ -1,0 +1,18 @@
+package cmd_version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersionCmd(version string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the CLI version",
+		Long:  "Print the current version of the Cubbit CLI",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("cubbit version %s\n", version)
+		},
+	}
+}

--- a/src/cmd/version/version_cmd.go
+++ b/src/cmd/version/version_cmd.go
@@ -11,8 +11,9 @@ func NewVersionCmd(version string) *cobra.Command {
 		Use:   "version",
 		Short: "Print the CLI version",
 		Long:  "Print the current version of the Cubbit CLI",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("cubbit version %s\n", version)
+			fmt.Fprintf(cmd.OutOrStdout(), "cubbit version %s\n", version)
 		},
 	}
 }

--- a/src/cmd/version/version_cmd_structure_test.go
+++ b/src/cmd/version/version_cmd_structure_test.go
@@ -18,8 +18,9 @@ func TestVersionCmd_Structure_PrintsVersion(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	if !bytes.Contains(commandOutput.Bytes(), []byte("cubbit version 1.2.3")) {
-		t.Fatalf("Expected output to contain 'cubbit version 1.2.3', got %q", commandOutput.String())
+	expectedOutput := "version version 1.2.3\n"
+	if commandOutput.String() != expectedOutput {
+		t.Fatalf("Expected output %q, got %q", expectedOutput, commandOutput.String())
 	}
 }
 

--- a/src/cmd/version/version_cmd_structure_test.go
+++ b/src/cmd/version/version_cmd_structure_test.go
@@ -1,0 +1,38 @@
+package cmd_version
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestVersionCmd_Structure_PrintsVersion(t *testing.T) {
+	versionCmd := NewVersionCmd("1.2.3")
+
+	commandOutput := new(bytes.Buffer)
+	versionCmd.SetOut(commandOutput)
+	versionCmd.SetErr(commandOutput)
+	versionCmd.SetArgs([]string{})
+
+	err := versionCmd.Execute()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !bytes.Contains(commandOutput.Bytes(), []byte("cubbit version 1.2.3")) {
+		t.Fatalf("Expected output to contain 'cubbit version 1.2.3', got %q", commandOutput.String())
+	}
+}
+
+func TestVersionCmd_Structure_RejectsArgs(t *testing.T) {
+	versionCmd := NewVersionCmd("1.2.3")
+
+	commandOutput := new(bytes.Buffer)
+	versionCmd.SetOut(commandOutput)
+	versionCmd.SetErr(commandOutput)
+	versionCmd.SetArgs([]string{"unexpected"})
+
+	err := versionCmd.Execute()
+	if err == nil {
+		t.Fatal("Expected error when passing arguments, got nil")
+	}
+}


### PR DESCRIPTION
### Summary
Replaces the `--version` flag with a dedicated `cubbit version` subcommand, following the same pattern used by other commands in the CLI (`auth`, `docs`, `config`, etc.).

### Motivation / Use Cases
The `--version` flag is a Cobra built-in that doesn't align with the CLI's command-based structure. A dedicated `version` command is more consistent and discoverable.

### Screenshots/Recordings (if CLI output changed)
```
$ cubbit version
cubbit version 1.6.1
```

### Tests
```bash
go build -o build/cubbit .
./build/cubbit version
# cubbit version 1.6.1

./build/cubbit --version
# Error: unknown flag: --version  ✓ flag removed
```

### Documentation
- [x] \`--help\` output updated (\`version\` appears as a subcommand in \`cubbit --help\`)

### Checklist
- [x] Tests added/updated (all existing tests pass)
- [x] Docs updated (README/changelog)
- [x] Checked lint/format
- [x] Backward compatibility considered (\`--version\` flag intentionally removed per COM-1083)